### PR TITLE
Ensure meta descriptions are set or removed

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,14 +8,12 @@
     
     <title>404</title>
     <meta name="author" content="Thu Le">
-    <meta name="description" content="">
     
     <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="website">
     <meta property="og:title" content="404">
-    <meta property="og:description" content="">
     <meta property="og:url" content="https://thu-le.com/404">
     <meta property="og:image" content="/assets/social-media-preview.png">
     
@@ -23,7 +21,6 @@
     <meta name="twitter:title" content="404">
     <meta name="twitter:creator" content="@_tple">
     <meta name="twitter:site" content="@_tple">
-    <meta name="twitter:description" content="">
     <meta name="twitter:image" content="/assets/social-media-preview.png">
     
     <link rel="icon" type="image/png" href="/assets/favicon.png">

--- a/blog/my-design-process.html
+++ b/blog/my-design-process.html
@@ -8,14 +8,14 @@
     
     <title>My design process</title>
     <meta name="author" content="Thu Le">
-    <meta name="description" content="">
+    <meta name="description" content="How I collect, connect, and correct the dots in my product design process.">
     
     <link rel="preload" href="/css/styles.css" as="style">
     <link rel="stylesheet" href="/css/styles.css">
     
     <meta property="og:type" content="article">
     <meta property="og:title" content="My design process">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="How I collect, connect, and correct the dots in my product design process.">
     <meta property="og:url" content="https://thu-le.com/blog/my-design-process">
     <meta property="og:image" content="/blog/images/ds-bk.webp">
     
@@ -23,7 +23,7 @@
     <meta name="twitter:title" content="My design process">
     <meta name="twitter:creator" content="@_tple">
     <meta name="twitter:site" content="@_tple">
-    <meta name="twitter:description" content="">
+    <meta name="twitter:description" content="How I collect, connect, and correct the dots in my product design process.">
     <meta name="twitter:image" content="/blog/images/ds-bk.webp">
     
     <link rel="icon" type="image/png" href="/assets/favicon.png">


### PR DESCRIPTION
## Summary
- drop empty description, OG, and Twitter description meta tags from `404.html`
- add a meaningful description and matching OG/Twitter descriptions on the design process blog post

## Testing
- `rg '<meta name="description" content=""' -n`
- `rg '<meta property="og:description" content=""' -n`
- `rg '<meta name="twitter:description" content=""' -n`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688edc0086288325a1f3005e7bf58399